### PR TITLE
Add GCP info workflow

### DIFF
--- a/.github/workflows/gcp-info.yml
+++ b/.github/workflows/gcp-info.yml
@@ -1,0 +1,26 @@
+name: Fetch GCP Info
+on:
+  workflow_dispatch:
+
+jobs:
+  gather:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Run query script
+        run: ./scripts/fetch_gcp_info.sh
+
+      - name: Upload info
+        uses: actions/upload-artifact@v3
+        with:
+          name: gcp-info
+          path: gcp-info.json
+

--- a/README.md
+++ b/README.md
@@ -33,4 +33,17 @@ Run `scripts/agent.py` to be guided through entering the required variables. The
 script can also generate a basic GitHub Actions workflow for running Terraform
 commands automatically.
 
+### Fetching GCP information
+
+The workflow `.github/workflows/gcp-info.yml` can query your Google Cloud
+environment for available projects and billing accounts. It uses the helper
+script `scripts/fetch_gcp_info.sh` which relies on the Google Cloud SDK.
+
+1. Add `GCP_PROJECT_ID` and `GCP_SA_KEY` secrets to your repository. The latter
+   should contain the JSON key for a service account with permission to list
+   projects and billing accounts.
+2. Trigger the **Fetch GCP Info** workflow from the GitHub Actions tab.
+3. After the job completes, download the `gcp-info` artifact to review the
+   generated `gcp-info.json` file.
+
 This structure follows the [Cloud Foundation Fabric](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric) style by separating version constraints, backend configuration and variable definitions.

--- a/scripts/fetch_gcp_info.sh
+++ b/scripts/fetch_gcp_info.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch basic GCP information using gcloud and store it as JSON.
+# Usage: ./scripts/fetch_gcp_info.sh [output-file]
+
+set -euo pipefail
+
+OUT_FILE="${1:-gcp-info.json}"
+
+# Ensure gcloud is initialized and authenticated before running.
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Query projects and billing accounts
+projects_file="$tmpdir/projects.json"
+billing_file="$tmpdir/billing.json"
+
+gcloud projects list --format=json > "$projects_file"
+gcloud billing accounts list --format=json > "$billing_file"
+
+# Combine results into a single JSON file
+jq -n \
+  --slurpfile projects "$projects_file" \
+  --slurpfile billing "$billing_file" \
+  '{projects: $projects[0], billing_accounts: $billing[0]}' \
+  > "$OUT_FILE"
+
+echo "GCP information written to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add new `fetch_gcp_info.sh` helper to query projects and billing accounts
- create `gcp-info.yml` workflow using service account to run the script
- document the workflow usage in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc5ab080c833288806bcf88f27669