### PR TITLE
Add Terraform web form

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Run `scripts/agent.py` to be guided through entering the required variables. The
 script can also generate a basic GitHub Actions workflow for running Terraform
 commands automatically.
 
+### Web form
+
+An alternative to the command line helper is the simple web form hosted with
+[GitHub Pages](https://rafiuskes.github.io/tfplan/). Open the page, enter the
+required values and click **Generate JSON** to obtain a `terraform.auto.tfvars.json`
+snippet.
+
+Save the generated JSON into a file named `terraform.auto.tfvars.json` in the
+repository root. Terraform will automatically load these variables on the next
+`terraform plan` or `terraform apply` run.
+
 ### Fetching GCP information
 
 The workflow `.github/workflows/gcp-info.yml` can query your Google Cloud

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Terraform Config Generator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    label { display: block; margin-top: 1rem; }
+    input { width: 300px; }
+    pre { background: #f0f0f0; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Terraform Configuration Helper</h1>
+  <p>Fill in the values below and click <strong>Generate JSON</strong> to get a <code>terraform.auto.tfvars.json</code> snippet.</p>
+  <form id="tf-form" onsubmit="return false;">
+    <label>Credentials file
+      <input type="text" id="credentials_file" placeholder="/path/to/key.json" required>
+    </label>
+    <label>Project ID
+      <input type="text" id="project_id" required>
+    </label>
+    <label>Region
+      <input type="text" id="region" placeholder="us-central1" required>
+    </label>
+    <label>Backend bucket
+      <input type="text" id="backend_bucket" required>
+    </label>
+    <label>User email
+      <input type="email" id="user_email" required>
+    </label>
+    <label>Group email
+      <input type="email" id="group_email" required>
+    </label>
+    <label>Billing account ID
+      <input type="text" id="billing_account_id" placeholder="XXXXXX-XXXXXX-XXXXXX" required>
+    </label>
+    <label>Budget currency code
+      <input type="text" id="budget_amount_currency_code" value="USD">
+    </label>
+    <label>Budget amount
+      <input type="number" id="budget_amount_units" value="100">
+    </label>
+    <label>Alert threshold percent
+      <input type="number" id="budget_threshold_percent" value="50">
+    </label>
+    <button type="button" onclick="generate()">Generate JSON</button>
+  </form>
+  <h2>terraform.auto.tfvars.json</h2>
+  <pre id="output"></pre>
+  <script>
+    function generate() {
+      const keys = [
+        'credentials_file',
+        'project_id',
+        'region',
+        'backend_bucket',
+        'user_email',
+        'group_email',
+        'billing_account_id',
+        'budget_amount_currency_code',
+        'budget_amount_units',
+        'budget_threshold_percent'
+      ];
+      const data = {};
+      keys.forEach(k => {
+        data[k] = document.getElementById(k).value.trim();
+      });
+      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/index.html` with a form for all variables defined in `scripts/agent.py`
- document the new GitHub Pages form in the README

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc8a632f08332bec3148aa33121ce